### PR TITLE
[FEAT] #1 local login 구현 완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ dependencies {
 	runtimeOnly "io.jsonwebtoken:jjwt-gson:${jjwtVersion}"
 
 	// Swagger/OpenAPI
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext {
-	set('jjwtVersion', '0.12.6')
+	set('jjwtVersion', '0.11.5')
 }
 
 dependencies {
@@ -36,10 +36,14 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// JWT
+	// jwt
 	implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
 	runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
-	runtimeOnly "io.jsonwebtoken:jjwt-gson:${jjwtVersion}"
+	runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
 	// Swagger/OpenAPI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/com/uplus/together/TogetherApplication.java
+++ b/src/main/java/com/uplus/together/TogetherApplication.java
@@ -1,9 +1,10 @@
 package com.uplus.together;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.uplus.together")
 public class TogetherApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/uplus/together/config/SecurityConfig.java
+++ b/src/main/java/com/uplus/together/config/SecurityConfig.java
@@ -1,31 +1,53 @@
 package com.uplus.together.config;
 
 // SecurityConfig.java
+import com.uplus.together.jwt.JwtUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
+    private final JwtUtils jwtUtils;
+
+    @Autowired
+    public SecurityConfig(@Lazy JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**",
-                                "/swagger-resources/**",
-                                "/webjars/**"
-                        ).permitAll()
+                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
-                )
-                .httpBasic(Customizer.withDefaults()) // 기본 인증은 유지
-                .csrf(csrf -> csrf.disable()); // CSRF 비활성화
+                );
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/uplus/together/config/SecurityConfig.java
+++ b/src/main/java/com/uplus/together/config/SecurityConfig.java
@@ -16,6 +16,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**",
+                                "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**"

--- a/src/main/java/com/uplus/together/config/SwaggerConfig.java
+++ b/src/main/java/com/uplus/together/config/SwaggerConfig.java
@@ -1,0 +1,51 @@
+package com.uplus.together.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi boardGroupedOpenApi() {
+        return GroupedOpenApi
+                .builder()
+                .group("together") // group 설정 (API들을 그룹화시켜 그룹에 속한 API들만 확인할 수 있도록 도와줌)
+                .pathsToMatch(  // group에 포함될 API endpoint 경로
+                        "/together/users/**"
+                ) // 여러 개의 경로 추가
+                .addOpenApiCustomizer(
+                        openApi ->
+                                openApi
+                                        .setInfo(
+                                                new Info()
+                                                        .title("TOGETHER API") // API 제목
+                                                        .description("TOGETHER API") // API 설명
+                                                        .version("1.0.0") // API 버전
+                                        )
+                )
+                .build();
+    }
+
+    // Bearer Token 인증 추가
+    @Bean
+    public OpenAPI api() {
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP) // Bearer Token 방식
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/java/com/uplus/together/config/WebConfig.java
+++ b/src/main/java/com/uplus/together/config/WebConfig.java
@@ -1,0 +1,39 @@
+package com.uplus.together.config;
+
+import com.uplus.together.jwt.JwtInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private JwtInterceptor jwtInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/together/**")
+                .excludePathPatterns(
+                        "/together/users/login",      // 로그인
+                        "/error",                  // Spring Boot 기본 에러 경로
+                        "/together/users/refresh",
+                        "/together/users/join",
+                        "/together/users/refresh", "/error"
+
+                        );
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("https://together-w8bl.onrender.com") // 또는 "*"
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .exposedHeaders("Set-Cookie");
+    }
+}

--- a/src/main/java/com/uplus/together/exception/CustomExceptions.java
+++ b/src/main/java/com/uplus/together/exception/CustomExceptions.java
@@ -1,0 +1,18 @@
+package com.uplus.together.exception;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomExceptions extends RuntimeException {
+    private final HttpStatus status;
+
+    public CustomExceptions(String message) {
+        super(message);
+        this.status = HttpStatus.BAD_REQUEST; // 기본 상태 코드
+    }
+
+    public CustomExceptions(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/uplus/together/exception/LoginException.java
+++ b/src/main/java/com/uplus/together/exception/LoginException.java
@@ -1,0 +1,9 @@
+package com.uplus.together.exception;
+
+public class LoginException extends Exception {
+
+    // 예외 메시지를 설정
+    public LoginException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uplus/together/jwt/JwtInterceptor.java
+++ b/src/main/java/com/uplus/together/jwt/JwtInterceptor.java
@@ -1,0 +1,64 @@
+package com.uplus.together.jwt;
+
+import com.uplus.together.jwt.JwtUtils;
+import jakarta.security.auth.message.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+// JWT를 이용한 인터셉터 구현
+@Component
+public class JwtInterceptor implements HandlerInterceptor {
+    private static final Logger logger = LoggerFactory.getLogger(JwtInterceptor.class);
+
+    private final JwtUtils jwtUtils; //JWT 유틸리티 객체 주입
+
+    @Autowired
+    public JwtInterceptor(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        String uri = request.getRequestURI();
+        System.out.println("uri:" + uri);
+
+        // 토큰 받기
+        System.out.println("preHandle 실행");
+
+        // 요청이 들어오면 실행되는 메서드
+        String accessToken = jwtUtils.getAccessToken(request); //헤더에서 액세스 토큰을 가져옴
+        System.out.println("Interceptor accessToken : " + accessToken); //요청 url 로깅을 위해 가져옴
+        //로깅용 URI
+        String requestURI = request.getRequestURI();
+
+        // 비회원일 때(액세스 토큰이 없을 때)
+        if (accessToken == null) {
+            logger.debug("비회원 유저입니다 URI : {}", requestURI);
+            throw new AuthException("UnAuthorized - Missing JWT Token");
+        } else {
+            logger.debug("access 존재합니다.");
+            System.out.println("access 존재합니다.");
+            // 액세스 토큰이 유효 시
+            if (jwtUtils.validateToken(accessToken)) {
+                logger.debug("유효한 토큰 정보입니다. URI : {}", requestURI);
+                System.out.println("유효" + requestURI);
+                return true;
+            } else {
+                //액세스 토큰이 유효하지 않을 시
+                logger.error("Invalid token: " + accessToken);
+                throw new AuthException("Unauthorized - Invalid JWT token");
+            }
+        }
+    }
+}

--- a/src/main/java/com/uplus/together/jwt/JwtUtils.java
+++ b/src/main/java/com/uplus/together/jwt/JwtUtils.java
@@ -1,0 +1,119 @@
+package com.uplus.together.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import jakarta.servlet.http.HttpServletRequest;  // 여기를 javax에서 jakarta로 변경
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtUtils {
+    private static final Logger logger = LoggerFactory.getLogger(JwtUtils.class);
+
+    @Value("${jwt.secret}")
+    private String SALT;
+
+    //accessToken 만료시간 설정
+    public final static long ACCESS_TOKEN_VALIDATION_SECOND = 1000L*60*60*12; //12시간
+    public final static long REFRESH_TOKEN_VALIDATION_SECOND = 1000L*60*60*24*30; //12시간
+    public static final String AUTHORIZATION_HEADER = "Authorization"; //헤더 이름
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = SALT.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 공통 JWT 생성 메서드
+    private String generateToken(String subject, String tokenType, long validityMillis) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validityMillis);
+
+        return Jwts.builder()
+                .setSubject(subject)
+                .claim("tokenType", tokenType)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // Access Token 생성
+    public String createAccessToken(String userEmail) {
+        return generateToken(userEmail, "ACCESS", ACCESS_TOKEN_VALIDATION_SECOND);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(String userEmail) {
+        return generateToken(userEmail, "REFRESH", REFRESH_TOKEN_VALIDATION_SECOND);
+    }
+
+    //토큰 유효성 검증 메서드
+    public boolean validateToken(String token){
+        //토큰 파싱 후 발생하는 예외를 캐치하여 문제가 있으면 false, 정상이면 true 반환
+        try{
+            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
+            return true;
+        }
+        catch (SignatureException e){
+            // 서명이 옳지 않을 때
+            System.out.println("잘못된 토큰 서명입니다.");
+        }
+        catch (ExpiredJwtException e){
+            // 토큰이 만료됐을 때
+            System.out.println("만료된 토큰입니다.");
+        }
+        catch(IllegalArgumentException | MalformedJwtException e){
+            // 토큰이 올바르게 구성되지 않았을 때 처리
+            System.out.println("잘못된 토큰입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 member_id를 추출하여 반환하는 메소드
+    public String getUserEmail(String token){
+        System.out.println("getUserEmail");
+
+        return Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    // HttpServletRequest에서 Authorization Header를 통해 access token을 추출하는 메서드입니다.
+    public String getAccessToken(HttpServletRequest httpServletRequest) {
+        String bearerToken = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String generateAccessTokenFromRefreshToken(String refreshToken) throws Exception {
+        if (!validateToken(refreshToken)) {
+            throw new Exception(refreshToken); // Refresh Token이 유효하지 않으면 예외 발생
+        }
+        String userId = getUserEmail(refreshToken);
+        return createAccessToken(userId); // 새로운 Access Token 생성
+    }
+
+
+    public String determineRedirectURI(HttpServletRequest httpServletRequest, String memberURI, String nonMemberURI) {
+        String token = getAccessToken(httpServletRequest);
+        if (token == null) {
+            return nonMemberURI; // 비회원용 URI로 리다이렉트
+        } else {
+            return memberURI; // 회원용 URI로 리다이렉트
+        }
+    }
+}

--- a/src/main/java/com/uplus/together/user/controller/LoginController.java
+++ b/src/main/java/com/uplus/together/user/controller/LoginController.java
@@ -1,0 +1,234 @@
+package com.uplus.together.user.controller;
+
+import com.uplus.together.exception.CustomExceptions;
+import com.uplus.together.exception.LoginException;
+import com.uplus.together.user.dto.member.MemberDTO;
+import com.uplus.together.jwt.JwtUtils;
+import com.uplus.together.user.service.login.LoginService;
+import com.uplus.together.user.service.login.LoginServiceImpl;
+import lombok.Getter;
+import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.scheduling.config.TaskExecutionOutcome.Status.SUCCESS;
+
+@RestController
+@RequestMapping("/together/users")
+public class LoginController {
+
+    // AuthenticationManager를 스프링에서 자동으로 주입받아 사용
+    // 사용자 인증을 위해 필요합니다.
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    LoginService loginService;
+
+    // JWT 토큰 생성을 위해 필요
+    @Autowired
+    private JwtUtils jwtUtils;
+    @Autowired
+    private LoginServiceImpl loginServiceImpl;
+
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@RequestBody MemberDTO memberDTO){
+        try {
+            MemberDTO authenticatedMember = loginService.checkLogin(memberDTO.getMember_email(), memberDTO.getMember_password());
+
+            String accessToken = jwtUtils.createAccessToken(authenticatedMember.getMember_email());
+            String refreshToken = jwtUtils.createRefreshToken(authenticatedMember.getMember_email());
+
+            loginServiceImpl.saveVerificationToken(authenticatedMember.getMember_email(), refreshToken);
+
+            Map<String, Object> userData = new HashMap<>();
+            userData.put("member_email", authenticatedMember.getMember_email());
+            userData.put("user_id", authenticatedMember.getId());
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("token", accessToken);
+            data.put("user", userData);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "success");
+            response.put("message", "로그인 성공");
+            response.put("data", data);
+
+            logger.info("Authenticated Member ID: " + authenticatedMember.getMember_email());
+
+            // accessToken을 쿠키에 담아 보내기
+            ResponseCookie refreshCookie = ResponseCookie.from("Refresh_Token", refreshToken)
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .sameSite("None")
+                    .maxAge(60 * 60 * 24 * 7) // 7일
+                    .build();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                    .body(response);
+
+        }
+        catch (LoginException e){    // Exception 나중에 LoginException 처럼 수정
+            logger.error("Login failed: {}", e.getMessage());
+            // 로그인 실패 시 형식 맞춤
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "fail");
+            response.put("message", e.getMessage());
+            response.put("data", null);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+        catch (CustomExceptions e){
+            logger.error("Authentication failed: {}", e.getMessage());
+            // 인증 실패 형식 맞춤
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "fail");
+            response.put("message", "인증 실패 : 이메일이나 비밀번호를 확인해주세요");
+            response.put("data", null);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+        catch(Exception e){
+            logger.error("Login error: ", e); // 전체 스택 트레이스를 출
+            logger.info("로그인 오류 상세: {}", e.getMessage());
+
+            // 서버 오류 형식 맞춤
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "서버 내부 오류");
+            response.put("data", null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+
+    // JWT 토큰을 담을 내부 클래스를 정의
+    @Getter
+    @Setter
+    class JwtResponse {
+        private String token;
+
+        // 생성자를 통해 토큰을 초기화
+        public JwtResponse(String token) {
+            this.token = token;
+        }
+    }
+
+    @GetMapping("test")
+    public String test() {
+        return "토큰 테스트";
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<?> logoutUser(@RequestBody Map<String, String> request) {
+        try {
+            String email = request.get("member_email");
+
+            // DB에서 refreshToken 삭제
+            loginServiceImpl.logout(email);
+
+            // 쿠키 제거
+            ResponseCookie deleteCookie = ResponseCookie.from("Refresh_Token", "")
+                    .path("/")
+                    .maxAge(0)
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("None")
+                    .build();
+
+            // 응답 생성
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "success");
+            response.put("message", "로그아웃 성공");
+            response.put("data", null);
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                    .body(response);
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            // 오류 응답
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "로그아웃 중 오류 발생: " + e.getMessage());
+            response.put("data", null);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+
+    private final String HEADER_AUTH = "Authorization";
+    private final String REFRESH_COOKIE = "Refresh_Token";
+
+    @Value("${jwt.access-token.expiretime}")
+    private long accessTokenExpireTime;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh( @RequestBody MemberDTO member
+            , @CookieValue(REFRESH_COOKIE) String refreshToken) {
+
+        logger.debug("refresh..............................refreshToken:{}", refreshToken);
+        String id = member.getMember_email();
+        Map<String, Object> result = new HashMap<>();
+        HttpStatus status = HttpStatus.OK;
+        HttpHeaders headers = new HttpHeaders();
+        try {
+            String myRefresh = loginService.getRefreshToken(id);
+            logger.debug("refresh..............................myRefresh:{}", myRefresh);
+            if(myRefresh.equals(refreshToken) && jwtUtils.validateToken(refreshToken)) {
+                String accessToken = jwtUtils.createAccessToken(member.getMember_email());
+                logger.debug("re id:{}  accessToken:{}", member.getMember_email(),  accessToken);
+                ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
+                        .httpOnly(true)
+                        .secure(true) // 배포 환경에서는 true로 변경하기
+                        .sameSite("None")
+                        .path("/")
+                        .maxAge(Duration.ofMillis(accessTokenExpireTime)) // 적절한 시간 설정
+                        .build();
+
+                headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+                result.put("message", SUCCESS);
+            }else {
+                logger.error("유효하지 않은 토큰");
+                result.put("message", "유효하지 않은 토큰");
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+        }catch (Exception e) {
+            logger.error("refresh 토큰 생성 실패:{}", e);
+            result.put("message", e.getMessage());
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return new ResponseEntity<Map<String, Object>>(result, headers, status);
+    }
+
+    public boolean isAuth(String userId, String authorHeader) {
+        logger.debug("search - Authorization:{}", authorHeader);
+        String token = authorHeader.replace("Bearer ", "");
+        if (!jwtUtils.validateToken(token))
+            return false;
+        String tokenId = jwtUtils.getUserEmail(authorHeader.replace("Bearer ", ""));
+        if (userId.equals(tokenId)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/uplus/together/user/controller/MemberController.java
+++ b/src/main/java/com/uplus/together/user/controller/MemberController.java
@@ -1,0 +1,111 @@
+package com.uplus.together.user.controller;
+
+import com.uplus.together.user.dto.member.MemberSignupDTO;
+import com.uplus.together.user.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequestMapping("/together/users")
+@RequiredArgsConstructor
+
+public class MemberController {
+
+    @Autowired
+    private MemberService memberService;
+
+    private  static final Logger logger
+            = LoggerFactory.getLogger(MemberController.class);
+
+
+    //회원가입
+    @PostMapping("/join")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> JoinRegister(@RequestBody MemberSignupDTO memberSignupDTO) {
+        String member_password = memberSignupDTO.getMember_password();
+        String member_name = memberSignupDTO.getMember_name();
+        String member_nickname = memberSignupDTO.getMember_nickname();
+        String member_email = memberSignupDTO.getMember_email();
+
+
+        // 이메일 중복 검사
+        if (memberService.isEmailDuplicated(member_email)) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "이미 있는 이메일입니다.");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+        }
+
+        // 닉네임 중복 검사
+        if (memberService.isIdDuplicated(member_nickname)) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "이미 있는 닉네임입니다.");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+        }
+
+
+        boolean result = memberService.register(member_email, member_password, member_name, member_nickname);
+        if (result) {
+            // 성공 메시지와 사용자 데이터를 담은 응답 생성
+            Map<String, Object> response = new HashMap<>();
+            Map<String, Object> userData = new HashMap<>();
+
+            userData.put("member_email", member_email);
+            userData.put("member_nickname", member_nickname);
+            userData.put("member_name", member_name);
+
+            response.put("status", "success");
+            response.put("message", "회원 가입 성공");
+            response.put("data", userData);
+
+            return ResponseEntity.ok(response);
+        } else {
+            // 실패 메시지를 담은 응답 생성
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "회원가입에 실패했습니다.");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+
+    //아이디 중복확인 (닉네임)
+    @GetMapping("/checkIdDuplicate/{member_nickname}")
+    public ResponseEntity<Map<String, Boolean>> checkIdDuplicate(@PathVariable String member_nickname) {
+        logger.info("중복검사 넘어온 아이디 : "+member_nickname);
+
+        boolean duplicate = memberService.isIdDuplicated(member_nickname);
+
+        logger.info("아이디 중복검사 : "+duplicate);
+        Map<String, Boolean> response = Collections.singletonMap("duplicate", duplicate);
+        return ResponseEntity.ok(response);
+    }
+
+
+    //이메일 중복확인
+    @GetMapping("/checkEmailDuplicate/{member_email}")
+    public ResponseEntity<Map<String, Boolean>> checkEmailDuplicate(@PathVariable String member_email) {
+        logger.info("중복검사 넘어온 이메일 : "+member_email);
+
+        boolean duplicate = memberService.isEmailDuplicated(member_email);
+
+        logger.info("이메일 중복검사 : "+duplicate);
+        Map<String, Boolean> response = Collections.singletonMap("duplicate", duplicate);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+}

--- a/src/main/java/com/uplus/together/user/dto/login/LoginDTO.java
+++ b/src/main/java/com/uplus/together/user/dto/login/LoginDTO.java
@@ -1,0 +1,12 @@
+package com.uplus.together.user.dto.login;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginDTO {
+    private String member_email; // id -> email
+    private String member_password; // password
+    private int delflag;
+}

--- a/src/main/java/com/uplus/together/user/dto/member/MemberDTO.java
+++ b/src/main/java/com/uplus/together/user/dto/member/MemberDTO.java
@@ -1,0 +1,27 @@
+package com.uplus.together.user.dto.member;
+
+
+import lombok.*;
+
+import java.sql.Blob;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDTO {
+    private String id;
+
+    private String member_password;     //비밀번호
+
+    private String member_email;    //이메일
+
+    private String member_name;     //이름
+
+    private String member_nickname;     //닉네임
+
+
+    private int delflag;
+
+}

--- a/src/main/java/com/uplus/together/user/dto/member/MemberSignupDTO.java
+++ b/src/main/java/com/uplus/together/user/dto/member/MemberSignupDTO.java
@@ -1,0 +1,17 @@
+package com.uplus.together.user.dto.member;
+
+import lombok.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberSignupDTO {
+    private Long id;
+    private String member_email;
+    private String member_password;
+    private String member_name;
+    private String member_nickname;
+}

--- a/src/main/java/com/uplus/together/user/repository/login/LoginMapper.java
+++ b/src/main/java/com/uplus/together/user/repository/login/LoginMapper.java
@@ -1,0 +1,29 @@
+package com.uplus.together.user.repository.login;
+
+import com.uplus.together.user.dto.login.LoginDTO;
+import com.uplus.together.user.dto.member.MemberDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Mapper
+public interface LoginMapper {
+    //로그인을 할 때 회원정보 조회 필요 id = #{member_id}이 부분은 실제 컬럼이랑 동일해야함
+    LoginDTO findByUsername(@Param("member_email") String username);
+
+    MemberDTO findByUsername2(@Param("member_email") String username);
+
+    void updateVerificationCode(@Param("member_email") String email, @Param("token") String token);
+
+    void clearVerificationCode(@Param("member_email") String email);
+
+    // 리프레시 토큰 저장 (update)
+    void saveRefreshToken(@Param("member_email") String email, @Param("token") String token);
+
+    // 리프레시 토큰 조회 (select)
+    String getRefreshToken(@Param("member_email") String email);
+
+    // 리프레시 토큰 삭제 (update)
+    void deleteRefreshToken(@Param("member_email") String email);
+}

--- a/src/main/java/com/uplus/together/user/repository/member/MemberMapper.java
+++ b/src/main/java/com/uplus/together/user/repository/member/MemberMapper.java
@@ -1,0 +1,18 @@
+package com.uplus.together.user.repository.member;
+
+import com.uplus.together.user.dto.member.MemberSignupDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MemberMapper {
+
+    //회원가입
+    int insert(MemberSignupDTO memberDTO);
+
+    //아이디 중복검사
+    boolean isIdDuplicated(String member_nickname);
+
+    //이메일 중복검사
+    boolean isEmailDuplicated(String member_email);
+
+}

--- a/src/main/java/com/uplus/together/user/service/login/LoginService.java
+++ b/src/main/java/com/uplus/together/user/service/login/LoginService.java
@@ -1,0 +1,13 @@
+package com.uplus.together.user.service.login;
+
+import com.uplus.together.user.dto.member.MemberDTO;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public interface LoginService { // username(UserDetailsService 인터페이스의 일부로서, Spring Security에서 제공)은 user id
+    UserDetails loadUserByUsername(String username) throws UsernameNotFoundException;
+    public MemberDTO checkLogin(String username, String password) throws Exception;
+
+    String getRefreshToken(String userEmail) throws Exception;
+
+}

--- a/src/main/java/com/uplus/together/user/service/login/LoginServiceImpl.java
+++ b/src/main/java/com/uplus/together/user/service/login/LoginServiceImpl.java
@@ -1,0 +1,86 @@
+package com.uplus.together.user.service.login;
+
+import com.uplus.together.user.dto.login.LoginDTO;
+import com.uplus.together.user.dto.member.MemberDTO;
+import com.uplus.together.exception.CustomExceptions;
+import com.uplus.together.user.repository.login.LoginMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+
+@Service("loginServiceImpl")
+@Transactional
+public class LoginServiceImpl implements LoginService, UserDetailsService {
+
+    private final LoginMapper loginMapper;
+    private final PasswordEncoder passwordEncoder;
+    private static final Logger logger = LoggerFactory.getLogger(LoginServiceImpl.class);
+
+    @Autowired
+    public LoginServiceImpl(LoginMapper loginMapper, PasswordEncoder passwordEncoder) {
+        this.loginMapper = loginMapper;
+        this.passwordEncoder = passwordEncoder; // PasswordEncoder 초기화
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username){
+        LoginDTO user = loginMapper.findByUsername(username);
+
+        if (user == null) {
+            // user가 null인 경우 예외 발생
+            throw new CustomExceptions("유저를 찾을 수 없습니다.");
+        }
+
+        // 유저의 권한을 설정하는 부분
+        return new org.springframework.security.core.userdetails.User(user.getMember_email(), user.getMember_password(), new ArrayList<>());
+    }
+
+
+    public MemberDTO checkLogin(String username, String password) throws Exception {
+        MemberDTO user = loginMapper.findByUsername2(username);
+
+        logger.debug("DB에서 조회된 이메일: " + (user != null ? user.getMember_email() : "NULL"));
+        logger.debug("DB에서 조회된 비밀번호: " + (user != null ? user.getMember_password() : "NULL"));
+
+
+        if (user == null) {
+            // user가 null인 경우 예외 발생
+            throw new Exception("유저를 찾을 수 없습니다.");
+        }
+
+
+        if (user.getDelflag() == 1) { // 추가: delflag가 1인 경우 예외 발생
+            throw new Exception("이미 삭제된 계정입니다.");
+        }
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(password, user.getMember_password()))
+            throw new Exception("password error");
+
+        return user;
+    }
+
+    public void saveVerificationToken(String email, String token) {
+        loginMapper.updateVerificationCode(email, token);
+    }
+
+    public void logout(String email) {
+        loginMapper.clearVerificationCode(email);
+    }
+
+
+    @Override
+    public String getRefreshToken(String userEmail) {
+        logger.debug("getRefreshToken:userEmail-{}  ", userEmail);
+        return loginMapper.getRefreshToken(userEmail);
+    }
+
+}
+

--- a/src/main/java/com/uplus/together/user/service/member/MemberService.java
+++ b/src/main/java/com/uplus/together/user/service/member/MemberService.java
@@ -1,0 +1,17 @@
+package com.uplus.together.user.service.member;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MemberService {
+
+    //회원가입
+    public boolean register(String member_email, String member_password, String member_name,
+                            String member_nickname);
+
+    //아이디 중복 검사
+    boolean isIdDuplicated(String member_nickname);
+
+    //이메일 중복 검사
+    boolean isEmailDuplicated(String member_email);
+}

--- a/src/main/java/com/uplus/together/user/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/uplus/together/user/service/member/MemberServiceImpl.java
@@ -1,0 +1,65 @@
+package com.uplus.together.user.service.member;
+
+import com.uplus.together.user.dto.member.MemberSignupDTO;
+import com.uplus.together.user.dto.member.MemberDTO;
+import com.uplus.together.user.repository.member.MemberMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class MemberServiceImpl implements MemberService{
+    private  static final Logger logger
+            = LoggerFactory.getLogger(MemberServiceImpl.class);
+    @Autowired
+    private  MemberMapper memberMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    //암호화 적용
+
+    @Override
+    public boolean register(String member_email, String member_password, String member_name,
+                            String member_nickname) {
+
+        MemberSignupDTO memberDTO = new MemberSignupDTO();
+        logger.info("암호화 전 비밀번호 : "+ member_password);
+        String encodedPassword = passwordEncoder.encode(member_password);
+        logger.info("암호화 후 비밀번호 : "+ encodedPassword);
+        memberDTO.setMember_password(encodedPassword);
+        memberDTO.setMember_name(member_name);
+        memberDTO.setMember_nickname(member_nickname);
+        memberDTO.setMember_email(member_email);
+
+
+        int result = memberMapper.insert(memberDTO);
+
+        return result == 1;
+    }
+
+
+    /* 닉네임 중복 검사 */
+    @Override
+    public boolean isIdDuplicated(String member_nickname) {
+        logger.info("서비스 넘어온 nickname : "+ member_nickname);
+        return memberMapper.isIdDuplicated(member_nickname);
+    }
+
+
+    /* 이메일 중복 검사 */
+    @Override
+    public boolean isEmailDuplicated(String member_email) {
+        logger.info("서비스 넘어온 email : "+ member_email);
+        return memberMapper.isEmailDuplicated(member_email);
+    }
+
+}

--- a/src/main/resources/mapper/LoginMapper.xml
+++ b/src/main/resources/mapper/LoginMapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- UserMapper.xml -->
+<mapper namespace="com.uplus.together.user.repository.login.LoginMapper">
+    <select id="findByUsername" resultType="com.uplus.together.user.dto.login.LoginDTO">
+        SELECT member_email, member_password, delflag FROM USERS WHERE member_email  = #{member_email}
+    </select>
+
+    <select id="findByUsername2" resultType="com.uplus.together.user.dto.member.MemberDTO">
+        SELECT * FROM USERS WHERE member_email = #{member_email}
+    </select>
+
+    <update id="updateVerificationCode">
+        UPDATE USERS
+        SET refresh_token = #{token}
+        WHERE member_email = #{member_email}
+    </update>
+
+    <update id="clearVerificationCode">
+        UPDATE USERS
+        SET refresh_token = NULL
+        WHERE member_email = #{member_email}
+    </update>
+
+    <update id="saveRefreshToken" parameterType="map">
+        update USERS
+        set refresh_token = #{token}
+        where member_email = #{member_email}
+    </update>
+
+    <select id="getRefreshToken" parameterType="string" resultType="string">
+        select refresh_token
+        from USERS
+        where member_email = #{member_email}
+    </select>
+
+    <update id="deleteRefreshToken" parameterType="string">
+        update USERS
+        set refresh_token = NULL
+        where member_email = #{member_email}
+    </update>
+</mapper>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.uplus.together.user.repository.member.MemberMapper">
+
+
+    <insert id="insert" parameterType="com.uplus.together.user.dto.member.MemberSignupDTO" useGeneratedKeys="true"
+            keyProperty="id">
+        INSERT INTO USERS (
+            member_email, member_password, member_nickname, member_name)
+        VALUES (#{member_email}, #{member_password}, #{member_nickname}, #{member_name})
+    </insert>
+
+
+
+    <select id="isIdDuplicated" parameterType="java.lang.String" resultType="java.lang.Boolean">
+        SELECT COUNT(*) > 0
+        FROM USERS
+        WHERE member_nickname = #{member_nickname}
+    </select>
+
+
+    <select id="isEmailDuplicated" parameterType="java.lang.String" resultType="java.lang.Boolean">
+        SELECT COUNT(*) > 0
+        FROM USERS
+        WHERE member_email = #{member_email}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1 

## 📝작업 내용

> 로컬 로그인 기능 구현 했습니다. 
> api는 로그인 /together/users/login, 로그아웃 /together/users/logout, 회원가입 /together/users/join 입니다.
> users 테이블에 member_email, member_password, delflag, member_name, member_nickname, refresh_token 칼럼 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
